### PR TITLE
chore(i18n): remove fallback to English

### DIFF
--- a/hostabee-element-mixin.html
+++ b/hostabee-element-mixin.html
@@ -158,8 +158,6 @@ This program is available under Apache License Version 2.0.
       _unregionalize() {
         if (this.language.includes('-')) {
           this.language = this.language.split('-')[0];
-        } else {
-          this.language = 'en';
         }
       }
 

--- a/test/hostabee-element_test.html
+++ b/test/hostabee-element_test.html
@@ -94,17 +94,6 @@
           element.language = 'en';
         });
 
-        it('should fallback to English if locales not found for the given language', function(done) {
-          element.addEventListener('app-localize-resources-loaded', function() {
-            expect(element.language).to.be.equal('en');
-            expect(element.localize('greetings')).to.be.equal('Hello!');
-            done();
-          }, {
-            once: true,
-          });
-          element.language = 'de';
-        });
-
         it('should allow to specify locales folder path', function(done) {
           element.addEventListener('app-localize-resources-loaded', function() {
             expect(element.localize('greetings')).to.be.equal('Hallo!');
@@ -129,6 +118,15 @@
           });
           element.localesFile = 'test/all.json';
           element.language = 'en';
+        });
+
+        it('should retry without region if locales file not found', function(done) {
+          element.language = 'fr-CA';
+          setTimeout(() => {
+            expect(element.language).to.be.equal('fr');
+            expect(element.localize('greetings')).to.be.equal('Bonjour !');
+            done();
+          }, 50);
         });
       });
     });


### PR DESCRIPTION
This commit removes the fallback to English when not locales file found
for the given language. This feature was preventing the user to specify
its own locales folder/file on its elements extending this one.